### PR TITLE
exit (and bye) implementation

### DIFF
--- a/exit.go
+++ b/exit.go
@@ -2,7 +2,7 @@
 
 // This file should be built to run correctly.
 // Because it finds the parent pid to kill.
-// If you use `go run` the `go` will be the parent.
+// If you use `go run` the `go` will be the parent...
 
 package main
 


### PR DESCRIPTION
it should be builded. if you use `go run` without building, go package will find `go` executable itself as the parent process.

my first running go code ^_^
