### PR TITLE
Fix sleep.go and make it coreutils ready

### DIFF
--- a/sleep.go
+++ b/sleep.go
@@ -4,42 +4,75 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
 	"time"
 )
 
+// text are copied from original coreutil sleep
+var (
+	help = `Usage: sleep NUMBER[SUFFIX]...
+  or:  sleep OPTION
+Pause for NUMBER seconds.  SUFFIX may be 's' for seconds (the default),
+'m' for minutes, 'h' for hours or 'd' for days.  Unlike most implementations
+that require NUMBER be an integer, here NUMBER may be an arbitrary floating
+point number.  Given two or more arguments, pause for the amount of time
+specified by the sum of their values.
+
+      --help     display this help and exit
+      --version  output version information and exit
+
+Report sleep bugs to bug-coreutils@gnu.org
+GNU coreutils home page: <http://www.gnu.org/software/coreutils/>
+General help using GNU software: <http://www.gnu.org/gethelp/>
+For complete documentation, run: info coreutils 'sleep invocation'
+`
+	version = `sleep (GNU coreutils) 8.20
+Copyright (C) 2012 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+Written by Jim Meyering and Paul Eggert.
+`
+
+	helpFlag    = flag.Bool("help", false, help)
+	versionFlag = flag.Bool("version", false, version)
+)
+
 func usage() {
-	fmt.Println("Usage: sleep seconds")
+	fmt.Printf("sleep: missing operand\nTry 'sleep --help' for more information.\n")
 }
 
 func main() {
 	flag.Parse()
-	if len(flag.Args()) != 1 {
+	if flag.NArg() == 0 && flag.NFlag() == 0 {
 		usage()
 		os.Exit(1)
 	}
 
-	i := flag.Arg(0)
-	sec, _ := strconv.Atoi(strings.TrimRight(i, "s"))
-	min, _ := strconv.Atoi(strings.TrimRight(i, "m"))
-	day, _ := strconv.Atoi(strings.TrimRight(i, "d"))
-
-	if strings.Contains(i, "s") {
-		time.Sleep(time.Duration(sec) * time.Second)
-		return
+	if *helpFlag {
+		fmt.Println(help)
+		os.Exit(0)
 	}
 
-	if strings.Contains(i, "m") {
-		time.Sleep(time.Duration(min) * time.Minute)
-		return
+	if *versionFlag {
+		fmt.Println(version)
+		os.Exit(0)
 	}
 
-	if strings.Contains(i, "d") {
-		time.Sleep(time.Duration(day) * time.Second * 86400)
-		return
+	var total time.Duration
+
+	// coreutil's sleep says: "Given two or more arguments, pause for the amount
+	// of time specified by the sum of their value"
+	for i := 0; i < flag.NArg(); i++ {
+		d, err := time.ParseDuration(flag.Arg(i))
+		if err != nil {
+			fmt.Printf("sleep: invalid time interval ‘%s’\n", flag.Arg(i))
+			os.Exit(1)
+		}
+
+		total = total + d
 	}
 
-	time.Sleep(time.Duration(i) * time.Second)
-
+	// sleep for a total time of passed times
+	time.Sleep(total)
 }


### PR DESCRIPTION
Following fixes are made:
- Better parsing (it's automatically now via time.ParseDuration)
- Better argument handling
- Current version was not building, fixed.
- Help and Version added (albeit version can be changed, it just a copy)
- Gnu Coreutil ready. That means the following works now:

```
./sleep 1s 3s 5s (will sleep for 8s)
./sleep 3s 1h (will sleep for 1 hour and 3s)
```
