### PR TITLE
Add CoreUtilsTestCase.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,40 @@
+import os
+import shlex
+import subprocess
+import tempfile
+import unittest
+
+
+class CoreUtilsTestCase(unittest.TestCase):
+
+    command = None
+
+    def get_process_output(self, cmd):
+        cmd = shlex.split('%s %s' % (self.command, cmd))
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        out, err = process.communicate()
+        rc = process.returncode
+        return out, err, rc
+
+    def check_output(self, finput, foutput, args=None):
+        """Saves the input to a temp file, runs the command,
+        matches the output.
+
+        """
+        # The *delete* parameter should be False,
+        # since we want to close the file and test it later.
+        with tempfile.NamedTemporaryFile(dir='.', delete=False) as f:
+            f.write(finput)
+        try:
+            if args is None:
+                cmd = '%s' % f.name
+            else:
+                cmd = '%s %s' % (args, f.name)
+            out, err, rc = self.get_process_output(cmd)
+
+            self.assertEqual(out, foutput)
+            if rc:
+                self.assertEqual(err, '')
+        finally:
+            os.unlink(f.name)

--- a/tests/test_head.py
+++ b/tests/test_head.py
@@ -1,70 +1,24 @@
-# this is the test implementation for head command,
-# gnu-coreutils uses perl but its really complicated to run
-# gnu's test suite and did i mention it uses perl.
-# 
-# anyways so i wrote a simple one in python.
-#
 import unittest
-import os
-from subprocess import Popen, PIPE
-from tempfile import NamedTemporaryFile
 
-class TestHead(unittest.TestCase):
+from . import CoreUtilsTestCase
 
-    def get_process_output(self, *args, **kwargs):
-        if 'exit_code' not in kwargs:
-            kwargs['exit_code'] = 0
-        process = Popen(args, stdout=PIPE)
-        exit_code = os.waitpid(process.pid, kwargs['exit_code'])
-        return process.communicate()[0]
 
-    def setUp(self):
-        pass
+class HeadTest(CoreUtilsTestCase):
 
-    def check_output(self, case):
-        """
-        saves the input to a temp file, runs the command, 
-        matches the output
-        """
-        # this should be false, since we want to close the
-        # file and test it later.
-        f = NamedTemporaryFile(dir=".", delete=False)
-        f.write(case['in'])
-        f.close()
-        #print f.name
-        has_params = 'params' in case
-        if 'params' in case:
-            args = []
-            args.append('../head')
-            for param in case['params']:
-                args.append(param)
-            args.append(f.name)
-            out = self.get_process_output(*args)
-        else:
-            out = self.get_process_output('../head', f.name)
-        
-        #print out
-        assert out == case['out']
-        # then we delete the tmp file
-        os.unlink(f.name)
+    command = './head'
 
     def test_head_lines(self):
-        self.check_output({'in':"", 'out':""})
-        self.check_output({'in':"1\n2\n3\n4\n5\n", 'out':"1\n2\n3\n4\n5\n"})
+        self.check_output('', '')
+        self.check_output('1\n2\n3\n4\n5\n', '1\n2\n3\n4\n5\n')
+        self.check_output('1\n2\n3\n4\n5\n', '1\n', args='-n 1')
         # missing last line
-        self.check_output({'in':"1x\n2x\n3\n4\n5x", 'out':"1x\n2x\n3\n4\n5x"})
-        # 
-        case = {'params':['-n', '1'],'in':"1\n2\n3\n4\n5\n", 'out':"1\n"}
-        self.check_output(case)
+        self.check_output('1x\n2x\n3\n4\n5x', '1x\n2x\n3\n4\n5x')
         # -n -2 check
-        case = {'params':['-n', '-2'],'in':"1\n2\n3\n4\n5\n", 'out':"1\n2\n3\n"}
-        self.check_output(case)
+        self.check_output('1\n2\n3\n4\n5\n', '1\n2\n3\n', args='-n -2')
 
     def test_head_bytes(self):
-        self.check_output({'params':['-c', '2'], 'in':"12345", 'out':"12"})
-        self.check_output({'params':['-c', '-2'], 'in':"12345", 'out':"123"})
-
-
+        self.check_output('12345', '12', args='-c 2')
+        self.check_output('12345', '123', args='-c -2')
 
 if __name__ == '__main__':
-    unittest.main() 
+    unittest.main()


### PR DESCRIPTION
- PEP8 fixleri yaptım
- Aybars'ın check_output metodunu daha generic hale getirdim
- Her test sınıfı aynı zamanda bir komutu test etmek için kullanılabilir
  
  ``` py
  class CatTest(CoreUtilsTestCase):
  
      command = './cat'
  ```
- Denemek için ana klasörde:
  `sh
  $ python -m unittest discover
  `
